### PR TITLE
Handle empty CSV input

### DIFF
--- a/main.go
+++ b/main.go
@@ -262,11 +262,14 @@ func mapInputData(data []byte, params tParams) (interface{}, error) {
 		return mapData, nil
 	case "csv":
 		var mapData []map[string]interface{}
-		r := csv.NewReader(strings.NewReader(string(data)))
+		r := csv.NewReader(bytes.NewReader(data))
 		r.Comma = prepareDelimiter(*params.inputDelimiter)
 		lines, err := r.ReadAll()
 		if err != nil {
 			return nil, fmt.Errorf("mapCSV: %s", err.Error())
+		}
+		if len(lines) == 0 {
+			return nil, fmt.Errorf("mapCSV: CSV has no rows")
 		}
 		mapData = make([]map[string]interface{}, len(lines[1:]))
 		headers := make([]string, len(lines[0]))

--- a/main_test.go
+++ b/main_test.go
@@ -17,6 +17,7 @@ func TestProcessTemplate(t *testing.T) {
 	outputFile := ""
 	textTemplate := `?{{define content}}`
 	getVersion := false
+	getHelp := false
 	chatGPTkey := ""
 	chatGPTmodel := ""
 	chatGPTquery := ""
@@ -28,6 +29,7 @@ func TestProcessTemplate(t *testing.T) {
 		outputFile:     &outputFile,
 		textTemplate:   &textTemplate,
 		getVersion:     &getVersion,
+		getHelp:        &getHelp,
 		chatGPTkey:     &chatGPTkey,
 		chatGPTmodel:   &chatGPTmodel,
 		chatGPTquery:   &chatGPTquery,
@@ -200,6 +202,11 @@ func TestMapInputData(t *testing.T) {
 	_, err = mapInputData(input, params)
 	if !strings.Contains(err.Error(), "wrong number of fields") {
 		t.Errorf("result: %v", err.Error())
+	}
+	input = []byte("")
+	_, err = mapInputData(input, params)
+	if err == nil || !strings.Contains(err.Error(), "CSV has no rows") {
+		t.Errorf("result: %v", err)
 	}
 
 	// Test map xml


### PR DESCRIPTION
## Summary
- Guard CSV parsing against empty input to avoid panics
- Switch CSV reader to use bytes.Reader and return a clear error when no rows are present
- Add regression test for empty CSV input

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bb578dd2dc832eb871b668fa41e821