### PR TITLE
Handle invalid ranges in randInt

### DIFF
--- a/functions.go
+++ b/functions.go
@@ -146,7 +146,12 @@ func mulf(a interface{}, v ...interface{}) float64 {
 }
 
 // randInt returns random integer in defined range {{randInt min max}} e.g. {{randInt 1 10}}
-func randInt(min, max int) int { return rand.Intn(max-min) + min }
+func randInt(min, max int) int {
+	if max <= min {
+		return min
+	}
+	return rand.Intn(max-min+1) + min
+}
 
 // round float {{round .val 2}} -> 2 decimals or {{round .val 1 0.4}} 0.4 round point
 func round(a interface{}, p int, rOpt ...float64) float64 {

--- a/functions_test.go
+++ b/functions_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"math/rand"
 	"regexp"
 	"strings"
 	"testing"
@@ -111,9 +112,18 @@ func TestMulf(t *testing.T) {
 }
 
 func TestRandInt(t *testing.T) {
-	result := randInt(50, 55)
-	if result < 50 || result > 55 {
-		t.Errorf("result: %v", result)
+	rand.Seed(1)
+	for i := 0; i < 1000; i++ {
+		result := randInt(50, 55)
+		if result < 50 || result > 55 {
+			t.Errorf("result: %v", result)
+		}
+	}
+	if randInt(5, 5) != 5 {
+		t.Errorf("expected 5, got: %v", randInt(5, 5))
+	}
+	if randInt(10, 5) != 10 {
+		t.Errorf("expected 10, got: %v", randInt(10, 5))
 	}
 }
 


### PR DESCRIPTION
## Summary
- ensure randInt handles non-increasing ranges and includes upper bound
- add tests for equal and reversed bounds

## Testing
- `go test ./...`
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bc62462680832e99ac72e84b522358